### PR TITLE
fix a bug when errors happens without response

### DIFF
--- a/src/shared/fend/progressbar-loading/config.interceptor.js
+++ b/src/shared/fend/progressbar-loading/config.interceptor.js
@@ -89,6 +89,12 @@ function(module) {
         },
 
         'response': function(response) {
+          if (!angular.isDefined(response)) {
+            console.error('No response defined. Aborting operation.');
+            setComplete();
+            return $q.reject(response);
+          }
+
           if (!isCached(response.config)) {
             reqsCompleted++;
             if (reqsCompleted >= reqsTotal) {


### PR DESCRIPTION
Sometimes errors happens on back-end and we don't receive any response (maybe the connection is broken by proxy network) and the loading progress bar stops in the middle at screen. 
Now, if there is no response object on the response callback, I use a $q.reject to ensure the promise's behavior correctly.
